### PR TITLE
Improve override example for easier understanding

### DIFF
--- a/src/terminology/overrides.md
+++ b/src/terminology/overrides.md
@@ -11,11 +11,16 @@ Below is a simple example of overriding a previously defined attribute's opinion
 ```admonish example title="override example"
 [![schematic](../images/terminology/overrides.png)](../images/terminology/overrides.png)
 
-1. The layer where an attribute's opinion is first authored (`/GEO/Cube.size`)
-2. a. The layer `cube_sphere_torus.usda` is brought into the layer `referenced.usda` via a composition mechanism called `referencing`  
-  b. An opinion is expressed on the already defined attribute `/GEO/Cube.size`, but in context of `cube_sphere_torus.usda`, essentially overriding what was there before
-3. The composed final result, aka the stage
+1. Shows `cube_sphere_torus.usda` where an attribute's [opinion] is first authored (`/GEO/Cube.size`)
+2. Shows `referenced.usda` where
+   * The layer `cube_sphere_torus.usda` is brought into the layer `referenced.usda` via a [composition] mechanism called `referencing`
+   * An opinion is expressed on the already defined attribute `/GEO/Cube.size`, but in context of `cube_sphere_torus.usda`, essentially overriding what was there before
+3. Shows the composed final result, aka the [stage]
 ```
+
+[composition]: composition.md
+[opinion]: opinions.md
+[stage]: stage.md
 
 ---
 


### PR DESCRIPTION
Reword items to make it more clear that they refer to the image. Add links to previously discussed items.
Fix markdown for the nested list.

Before:
![image](https://user-images.githubusercontent.com/2787581/235446474-983e08a4-728c-411e-8a5f-d44a6bb77a6f.png)

After:
![image](https://user-images.githubusercontent.com/2787581/235446339-762cc4d2-8060-4d3b-aba2-c277c9b82f73.png)
